### PR TITLE
fix #1051: Best efforts to clear ipvs rules.

### DIFF
--- a/pkg/bootstrap/os/tasks.go
+++ b/pkg/bootstrap/os/tasks.go
@@ -163,6 +163,7 @@ var (
 		"iptables -X",
 		"iptables -F -t nat",
 		"iptables -X -t nat",
+		"ipvsadm -C",
 		"ip link del kube-ipvs0",
 		"ip link del nodelocaldns",
 	}
@@ -173,7 +174,9 @@ type ResetNetworkConfig struct {
 }
 
 func (r *ResetNetworkConfig) Execute(runtime connector.Runtime) error {
-	_, _ = runtime.GetRunner().SudoCmd(strings.Join(networkResetCmds, " && "), true)
+	for _, cmd := range networkResetCmds {
+		_, _ = runtime.GetRunner().SudoCmd(cmd, true)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: laminar <fangtian@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
